### PR TITLE
feat: configure project-id and project-number

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This is an opinionated plugin to authenticate to the elastic-observability Googl
 
 ## Properties
 
-| Name       | Description                                                                                           | Required | Default |
-|------------|-------------------------------------------------------------------------------------------------------|----------|---------|
-| `lifetime` | The time (in seconds) the OIDC token will be valid for before expiry. Must be a non-negative integer. | `false`  | `1800`  |
+| Name             | Description                                                                                           | Required | Default                 |
+|------------------|-------------------------------------------------------------------------------------------------------|----------|-------------------------|
+| `lifetime`       | The time (in seconds) the OIDC token will be valid for before expiry. Must be a non-negative integer. | `false`  | `1800`                  |
+| `project-number` | The GCP project number.                                                                               | `false`  | `8560181848`            |
+| `project-id`     | The GCP project id.                                                                                   | `false`  | `elastic-observability` |
 
 ## Usage
 

--- a/hooks/environment
+++ b/hooks/environment
@@ -8,8 +8,9 @@ TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'buildkiteXXXX')
 echo "~~~ :buildkite: Requesting OIDC token from Buildkite"
 
 HASH=$(echo "${BUILDKITE_REPO}" | awk -F'[:.]' '{ printf $3 }' | sha256sum | cut -c1-27)
-PROJECT_NUMBER="8560181848"
-PROJECT_ID="elastic-observability"
+
+PROJECT_NUMBER="${BUILDKITE_PLUGIN_OBLT_GOOGLE_AUTH_PROJECT_NUMBER:-"8560181848"}"
+PROJECT_ID="${BUILDKITE_PLUGIN_OBLT_GOOGLE_AUTH_PROJECT_ID:-"elastic-observability"}"
 WORKLOAD_IDENTITY_POOL_ID="buildkite"
 WORKLOAD_IDENTITY_PROVIDER_ID="repo-${HASH}"
 AUDIENCE="//iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${WORKLOAD_IDENTITY_POOL_ID}/providers/${WORKLOAD_IDENTITY_PROVIDER_ID}"

--- a/plugin.yml
+++ b/plugin.yml
@@ -9,4 +9,8 @@ configuration:
   properties:
     lifetime:
       type: number
+    project-id:
+      type: string
+    project-number:
+      type: number
   additionalProperties: false


### PR DESCRIPTION
Notifies https://github.com/elastic/elastic-agent/pull/7232

### What

Customise the project-id and project-number so we can support different GCPs.

### Test


I'm testing this out in Buldkite, see [build](https://buildkite.com/elastic/elastic-agent-helm-charts/builds/6) [it's not accessible for everyone but only elastic employees]