### PR TITLE
Stop using anchors in the bk pipeline

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,10 +30,10 @@ steps:
       provider: gcp
     plugins:
       - elastic/oblt-google-auth#${BUILDKITE_COMMIT}:
-        lifetime: 10800 # seconds
-        project-id: "elastic-observability-ci"
-        project-number: "911195782929"
-        use-service-account: true
+          lifetime: 10800 # seconds
+          project-id: "elastic-observability-ci"
+          project-number: "911195782929"
+          use-service-account: true
     command: |
       #!/usr/bin/env bash
       set +eu

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,9 +15,9 @@ steps:
       provider: gcp
     plugins:
       - elastic/oblt-google-auth#${BUILDKITE_COMMIT}:
-        lifetime: 10800 # seconds
-        project-id: "elastic-observability-ci"
-        project-number: "911195782929"
+          lifetime: 10800 # seconds
+          project-id: "elastic-observability-ci"
+          project-number: "911195782929"
     command: |
       #!/usr/bin/env bash
       set +eu

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,7 @@ steps:
   - label: ":gcp: Google Cloud Auth OIDC Test"
     agents:
       provider: gcp
+      image: family/core-ubuntu-2204
     plugins:
       - elastic/oblt-google-auth#${BUILDKITE_COMMIT}:
           lifetime: 10800 # seconds
@@ -28,6 +29,7 @@ steps:
   - label: ":gcp: Google Cloud Auth Service Account Test"
     agents:
       provider: gcp
+      image: family/core-ubuntu-2204
     plugins:
       - elastic/oblt-google-auth#${BUILDKITE_COMMIT}:
           lifetime: 10800 # seconds

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,7 +14,10 @@ steps:
     agents:
       provider: gcp
     plugins:
-      - *google_oidc_plugin
+      - elastic/oblt-google-auth#${BUILDKITE_COMMIT}:
+        lifetime: 10800 # seconds
+        project-id: "elastic-observability-ci"
+        project-number: "911195782929"
     command: |
       #!/usr/bin/env bash
       set +eu
@@ -26,8 +29,11 @@ steps:
     agents:
       provider: gcp
     plugins:
-      - *google_oidc_plugin:
-          use-service-account: true
+      - elastic/oblt-google-auth#${BUILDKITE_COMMIT}:
+        lifetime: 10800 # seconds
+        project-id: "elastic-observability-ci"
+        project-number: "911195782929"
+        use-service-account: true
     command: |
       #!/usr/bin/env bash
       set +eu


### PR DESCRIPTION
## Summary

Stop using anchors because apparently the `BUILDKITE_COMMIT` var is no accessible in the `common` pipeline section.